### PR TITLE
fiexed compositionstart at end of link element

### DIFF
--- a/packages/slate-react/src/components/editable.tsx
+++ b/packages/slate-react/src/components/editable.tsx
@@ -828,20 +828,22 @@ export const Editable = (props: EditableProps) => {
                     Editor.deleteFragment(editor)
                     return
                   }
-                  const inline = Editor.above(editor, {
-                    match: n => Editor.isInline(editor, n),
-                    mode: 'highest',
-                  })
-                  if (inline) {
-                    const [, inlinePath] = inline
-                    if (Editor.isEnd(editor, selection.anchor, inlinePath)) {
-                      const point = Editor.after(editor, inlinePath)!
-                      Transforms.setSelection(editor, {
-                        anchor: point,
-                        focus: point,
-                      })
-                    }
-                  }
+
+                  // const inline = Editor.above(editor, {
+                  //   match: n => Editor.isInline(editor, n),
+                  //   mode: 'highest',
+                  // })
+                  // if (inline) {
+                  //   const [, inlinePath] = inline
+                  //   if (Editor.isEnd(editor, selection.anchor, inlinePath)) {
+                  //     const point = Editor.after(editor, inlinePath)!
+                  //     Transforms.setSelection(editor, {
+                  //       anchor: point,
+                  //       focus: point,
+                  //     })
+                  //   }
+                  // }
+
                   // insert new node in advance to ensure composition text will insert
                   // along with final input text
                   // add Unicode BOM prefix to avoid normalize removing this node


### PR DESCRIPTION
**Description**
https://www.slatejs.org/examples/inlines
this example when i input Chinese at the end of link element, focus lose when i start input;
like this, my first character is s
![image](https://user-images.githubusercontent.com/16861647/151317540-3b1aeb5f-b7ac-4a7e-bbe8-33ee942b7ada.png)

when i comment in this file packages/slate-react/src/components/editable.tsx
![image](https://user-images.githubusercontent.com/16861647/151318604-a54e0ab1-7879-4aa9-a88e-fce61a6a6829.png)

**Issue**
Fixes: (link to issue)


**Example**
A GIF or video showing the old and new behaviors after this pull request is merged. Or a code sample showing the usage of a new API. (If you don't include this, your pull request will not be reviewed as quickly, because it's much too hard to figure out exactly what is going wrong, and it makes maintenance much harder.)

**Context**
If your change is non-trivial, please include a description of how the new logic works, and why you decided to solve it the way you did. (This is incredibly helpful so that reviewers don't have to guess your intentions based on the code, and without it your pull request will likely not be reviewed as quickly.)

**Checks**
- [ ] The new code matches the existing patterns and styles.
- [ ] The tests pass with `yarn test`.
- [ ] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [ ] The relevant examples still work. (Run examples with `yarn start`.)
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `yarn changeset add`.)

